### PR TITLE
feat: 支持 Params 中 List<T> 泛型解析，新增 MCP outputSchema 构建能力

### DIFF
--- a/solon-ai-core/src/main/java/org/noear/solon/ai/annotation/ToolMapping.java
+++ b/solon-ai-core/src/main/java/org/noear/solon/ai/annotation/ToolMapping.java
@@ -48,4 +48,9 @@ public @interface ToolMapping {
      * 结果转换器
      */
     Class<? extends ToolCallResultConverter> resultConverter() default ToolCallResultConverter.class;
+
+    /**
+     * 是否启用 响应OutputSchema 自动提取
+     */
+    boolean enableOutputSchema() default false;
 }

--- a/solon-ai-core/src/main/java/org/noear/solon/ai/chat/tool/FunctionTool.java
+++ b/solon-ai-core/src/main/java/org/noear/solon/ai/chat/tool/FunctionTool.java
@@ -61,6 +61,22 @@ public interface FunctionTool extends ChatTool {
     String inputSchema();
 
     /**
+     * 输入架构
+     *
+     * <pre>{@code
+     * JsonSchema {
+     *     String type;
+     *     Map<String, Object> properties;
+     *     List<String> required;
+     *     Boolean additionalProperties;
+     * }
+     * }</pre>
+     */
+    default String outputSchema() {
+        return null;
+    }
+
+    /**
      * 处理
      */
     String handle(Map<String, Object> args) throws Throwable;

--- a/solon-ai-core/src/main/java/org/noear/solon/ai/chat/tool/MethodFunctionTool.java
+++ b/solon-ai-core/src/main/java/org/noear/solon/ai/chat/tool/MethodFunctionTool.java
@@ -105,7 +105,7 @@ public class MethodFunctionTool implements FunctionTool {
         if (enableOutputSchema) {
             Type returnType = method.getGenericReturnType();
             ONode outputSchemaNode = new ONode();
-            // 如果有泛型，则需要处理
+            // 如果返回类型，则需要处理
             if (returnType != void.class) {
                 ParamDesc returnDesc = new ParamDesc("", getRawClass(returnType), false, "");
                 ToolSchemaUtil.buildToolParamNode(returnType, returnDesc.description(), outputSchemaNode);

--- a/solon-ai-mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
+++ b/solon-ai-mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java
@@ -810,9 +810,10 @@ public final class McpSchema {
 		@JsonProperty("description") String description;
 		@JsonProperty("returnDirect") Boolean returnDirect;
 		@JsonProperty("inputSchema") JsonSchema inputSchema;
+		@JsonProperty("outputSchema") JsonSchema outputSchema;
 
-		public Tool(String name, String description, Boolean returnDirect, String schema) {
-			this(name, description, returnDirect, parseSchema(schema));
+		public Tool(String name, String description, Boolean returnDirect, String inSchemaJson, String outSchemaJson) {
+			this(name, description, returnDirect, parseSchema(inSchemaJson), outSchemaJson != null && !outSchemaJson.isEmpty() ? parseSchema(outSchemaJson) : null);
 		}
 
 	} // @formatter:on

--- a/solon-ai-mcp/src/test/java/demo/ai/mcp/server/outputschema/OutputSchemaMcpTool.java
+++ b/solon-ai-mcp/src/test/java/demo/ai/mcp/server/outputschema/OutputSchemaMcpTool.java
@@ -1,0 +1,69 @@
+package demo.ai.mcp.server.outputschema;
+
+import demo.ai.mcp.server.outputschema.dataobject.CityInfo;
+import demo.ai.mcp.server.outputschema.dataobject.Result;
+import demo.ai.mcp.server.outputschema.dataobject.UserInfo;
+import org.noear.solon.ai.annotation.ToolMapping;
+import org.noear.solon.ai.mcp.server.annotation.McpServerEndpoint;
+import org.noear.solon.annotation.Param;
+
+import java.util.*;
+
+/**
+ * 自动生成 outputSchema 测试类：
+ * 基础类型（String）
+ * POJO 对象（UserInfo）
+ * 泛型集合（List<CityInfo>）
+ * Map<String, Object>
+ * 泛型包装类（Result<UserInfo>）
+ * Optional<T>
+ * 数组（String[]）
+ * 官方说明：https://modelcontextprotocol.io/specification/draft/server/tools#output-schema
+ * 输出：data:{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"getTags","description":"获取标签列表","returnDirect":false,"inputSchema":{"type":"object","properties":{},"required":[]},"outputSchema":{"type":"object","properties":{"code":{"type":"string"},"message":{"type":"string"},"data":{"type":"array","items":{"type":"string"}}}}},{"name":"getWeather","description":"查询天气预报","returnDirect":false,"inputSchema":{"type":"object","properties":{"city":{"description":"城市","type":"string"}},"required":["city"]},"outputSchema":{"type":"string"}},{"name":"getWeather0","description":"查询天气预报","returnDirect":false,"inputSchema":{"type":"object","properties":{"city":{"description":"城市","type":"string"}},"required":["city"]}},{"name":"listCities","description":"获取所有城市信息","returnDirect":false,"inputSchema":{"type":"object","properties":{},"required":[]},"outputSchema":{"type":"object","properties":{"code":{"type":"string"},"message":{"type":"string"},"data":{"type":"array","items":{"type":"object","properties":{"name":{"description":"城市名","type":"string"},"code":{"description":"城市编码","type":"string"}},"required":["name","code"]}}}}},{"name":"getConfigs","description":"获取配置项","returnDirect":false,"inputSchema":{"type":"object","properties":{},"required":[]},"outputSchema":{"type":"object","properties":{"type":"object","properties":{},"required":[]}}},{"name":"getCurrentUser","description":"获取当前用户信息","returnDirect":false,"inputSchema":{"type":"object","properties":{},"required":[]},"outputSchema":{"type":"object","properties":{"code":{"type":"string"},"message":{"type":"string"},"data":{"type":"object","properties":{"name":{"description":"用户名","type":"string"},"age":{"description":"年龄","type":"integer"}},"required":["name","age"]}}}},{"name":"getSetting","description":"获取某个设置项","returnDirect":false,"inputSchema":{"type":"object","properties":{"key":{"description":"键","type":"string"}},"required":["key"]},"outputSchema":{"type":"string"}},{"name":"getUserInfo","description":"获取用户信息","returnDirect":false,"inputSchema":{"type":"object","properties":{"userId":{"description":"用户ID","type":"integer"}},"required":["userId"]},"outputSchema":{"type":"object","properties":{"name":{"description":"用户名","type":"string"},"age":{"description":"年龄","type":"integer"}},"required":["name","age"]}}]}}
+ * @author ityangs@163.com 2025年05月20日15:54:04
+ */
+@McpServerEndpoint(sseEndpoint = "/mcp/outputSchema/sse")
+public class OutputSchemaMcpTool {
+
+    @ToolMapping(description = "查询天气预报")
+    public String getWeather0(@Param(description = "城市") String city) {
+        return "晴，14度";
+    }
+
+    @ToolMapping(description = "查询天气预报", enableOutputSchema = true)
+    public String getWeather(@Param(description = "城市") String city) {
+        return "晴，14度";
+    }
+
+    @ToolMapping(description = "获取用户信息", enableOutputSchema = true)
+    public UserInfo getUserInfo(@Param(description = "用户ID") Long userId) {
+        return new UserInfo(); // 假设 UserInfo 有 name、age 字段
+    }
+
+    @ToolMapping(description = "获取所有城市信息", enableOutputSchema = true)
+    public Result<List<CityInfo>> listCities() {
+        return Result.ok(Arrays.asList(new CityInfo()));
+    }
+
+    @ToolMapping(description = "获取配置项", enableOutputSchema = true)
+    public Map<String, Object> getConfigs() {
+        return Collections.singletonMap("env", "prod"); // 返回单一键值对的 Map
+    }
+
+    @ToolMapping(description = "获取当前用户信息", enableOutputSchema = true)
+    public Result<UserInfo> getCurrentUser() {
+        return Result.ok(new UserInfo());
+    }
+
+    @ToolMapping(description = "获取某个设置项", enableOutputSchema = true)
+    public Optional<String> getSetting(@Param(description = "键") String key) {
+        return Optional.of("值");
+    }
+
+
+    @ToolMapping(description = "获取标签列表", enableOutputSchema = true)
+    public Result<String[]> getTags() {
+        return Result.ok(new String[]{"天气", "推荐"});
+    }
+
+}

--- a/solon-ai-mcp/src/test/java/demo/ai/mcp/server/outputschema/dataobject/CityInfo.java
+++ b/solon-ai-mcp/src/test/java/demo/ai/mcp/server/outputschema/dataobject/CityInfo.java
@@ -1,0 +1,18 @@
+package demo.ai.mcp.server.outputschema.dataobject;
+
+import org.noear.solon.annotation.Param;
+
+/**
+ * @Auther: ityangs@163.com
+ * @Date: 2025/5/20 16:01
+ * @Description:
+ */
+public class CityInfo {
+    @Param(description = "城市名")
+    private String name;
+
+    @Param(description = "城市编码")
+    private String code;
+
+    // 构造器、getter、setter 省略
+}

--- a/solon-ai-mcp/src/test/java/demo/ai/mcp/server/outputschema/dataobject/Result.java
+++ b/solon-ai-mcp/src/test/java/demo/ai/mcp/server/outputschema/dataobject/Result.java
@@ -1,0 +1,20 @@
+package demo.ai.mcp.server.outputschema.dataobject;
+
+/**
+ * @Auther: ityangs@163.com
+ * @Date: 2025/5/20 15:59
+ * @Description:
+ */
+public class Result<T> {
+    private String code;
+    private String message;
+    private T data;
+
+    // 省略构造器、getter、setter
+
+    public static <T> Result<T> ok(T data) {
+        Result<T> result = new Result<>();
+        return result;
+    }
+}
+

--- a/solon-ai-mcp/src/test/java/demo/ai/mcp/server/outputschema/dataobject/UserInfo.java
+++ b/solon-ai-mcp/src/test/java/demo/ai/mcp/server/outputschema/dataobject/UserInfo.java
@@ -1,0 +1,17 @@
+package demo.ai.mcp.server.outputschema.dataobject;
+
+import org.noear.solon.annotation.Param;
+
+/**
+ * @Auther: ityangs@163.com
+ * @Date: 2025/5/20 15:59
+ * @Description:
+ */
+public class UserInfo {
+    @Param(description = "用户名")
+    private String name;
+
+    @Param(description = "年龄")
+    private Integer age;
+}
+


### PR DESCRIPTION
### 这个 PR 有什么用 / 我们为什么需要它？

- 🐞 修复了 `@Params` 注解中 `List<T>` 泛型未能正确生成 schema 的问题；
- ✨ 为 MCP 工具新增支持自动解析 `outputSchema`；
  - **背景**：在 MCP 协议的 `FunctionTool` 定义中新增了 `outputSchema` 字段，用于明确服务的输出结构。此改进有助于：
    - 使协议更加标准化；
    - 提升大模型对工具返回结构的理解能力；
    - 提高调用的准确性与稳定性。
  - 📚 官方文档：[Model Context Protocol - Output Schema](https://modelcontextprotocol.io/specification/draft/server/tools#output-schema)
- ⚙️ `@ToolMapping` 注解新增开关 `enableOutputSchema`，用于控制是否启用自动构建 `outputSchema` 的逻辑。  
  - **用法示例**：  
    ```java
    @ToolMapping(description = "查询天气预报", enableOutputSchema = true)
    输出对象参数字段标志注解：@Param；与入参同注解
    ```

---

### 总结您的更改

- 🐞 修复泛型 `List<T>` 在 schema 构建中的解析问题；
- ✨ 支持 MCP 工具自动生成 `outputSchema`；
- ⚙️ 为 `@ToolMapping` 注解添加 `enableOutputSchema` 开关控制。

---

### 关联 Issue
Closes #26
---

#### ✅ 请确认以下事项：

- [x] 已确保所有测试通过，必要时已补充测试用例；---OutputSchemaMcpTool下
- [x]  提交信息已遵循 [Conventional Commits](https://www.conventionalcommits.org/) 规范；
- [x] 已评估对文档的影响，并在需要时补充或准备提交文档更新。
