### PR TITLE
feat(gemini): 添加模型配置类及转换工具

### DIFF
--- a/solon-ai-llm-dialects/solon-ai-dialect-gemini/src/main/java/org/noear/solon/ai/llm/dialect/gemini/GeminiChatDialect.java
+++ b/solon-ai-llm-dialects/solon-ai-dialect-gemini/src/main/java/org/noear/solon/ai/llm/dialect/gemini/GeminiChatDialect.java
@@ -22,6 +22,8 @@ import org.noear.solon.ai.chat.*;
 import org.noear.solon.ai.chat.dialect.AbstractChatDialect;
 import org.noear.solon.ai.chat.message.AssistantMessage;
 import org.noear.solon.ai.chat.message.ChatMessage;
+import org.noear.solon.ai.llm.dialect.gemini.model.GeminiConfigConverter;
+import org.noear.solon.ai.llm.dialect.gemini.model.GenerationConfig;
 import org.noear.solon.net.http.HttpUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -382,42 +384,8 @@ public class GeminiChatDialect extends AbstractChatDialect {
             if ("generationConfig".equals(key) && value instanceof Map) {
                 Map<?, ?> genConfig = (Map<?, ?>) value;
                 ONode genConfigNode = root.getOrNew("generationConfig");
-                
-                for (Map.Entry<?, ?> genKv : genConfig.entrySet()) {
-                    String genKey = genKv.getKey().toString();
-                    Object genValue = genKv.getValue();
-                    
-                    if ("temperature".equals(genKey) || "topP".equals(genKey)) {
-                        if (genValue instanceof String) {
-                            genValue = Double.parseDouble((String) genValue);
-                        }
-                        genConfigNode.set(genKey, genValue);
-                    } else if ("thinkingBudget".equals(genKey)) {
-                        if (genValue instanceof String) {
-                            genValue = Integer.parseInt((String) genValue);
-                        }
-                        genConfigNode.set(genKey, genValue);
-                    } else if ("thinkingConfig".equals(genKey) && genValue instanceof Map) {
-                         ONode thinkingConfigNode = genConfigNode.getOrNew("thinkingConfig");
-                         Map<?, ?> thinkingConfig = (Map<?, ?>) genValue;
-                         for (Map.Entry<?, ?> tcKv : thinkingConfig.entrySet()) {
-                             String tcKey = tcKv.getKey().toString();
-                             Object tcValue = tcKv.getValue();
-                             if ("includeThoughts".equals(tcKey)) {
-                                 if (tcValue instanceof String) {
-                                     tcValue = Boolean.parseBoolean((String) tcValue);
-                                 }
-                             } else if ("thinkingBudget".equals(tcKey)) {
-                                 if (tcValue instanceof String) {
-                                     tcValue = Integer.parseInt((String) tcValue);
-                                 }
-                             }
-                             thinkingConfigNode.set(tcKey, tcValue);
-                         }
-                    } else {
-                        genConfigNode.set(genKey, ONode.ofBean(genValue));
-                    }
-                }
+                GenerationConfig generationConfig = GeminiConfigConverter.toGenerationConfig((Map<String, Object>) genConfig);
+                root.set("generationConfig", ONode.ofBean(generationConfig));
             } else {
                 root.set(key, ONode.ofBean(value));
             }

--- a/solon-ai-llm-dialects/solon-ai-dialect-gemini/src/main/java/org/noear/solon/ai/llm/dialect/gemini/model/GeminiConfigConverter.java
+++ b/solon-ai-llm-dialects/solon-ai-dialect-gemini/src/main/java/org/noear/solon/ai/llm/dialect/gemini/model/GeminiConfigConverter.java
@@ -1,0 +1,559 @@
+/*
+ * Copyright 2017-2025 noear.org and authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.noear.solon.ai.llm.dialect.gemini.model;
+
+import java.lang.reflect.Field;
+import java.util.*;
+
+/**
+ * Gemini 配置转换工具
+ * <p>
+ * 用于将 Map<String, Object> 类型的配置转换为 GenerationConfig 等配置对象。
+ * 支持递归解析嵌套对象、自动类型转换和枚举值匹配。
+ * <p>
+ * 使用示例：
+ * <pre>{@code
+ * Map<String, Object> configMap = new HashMap<>();
+ * configMap.put("temperature", 0.7);
+ * configMap.put("maxOutputTokens", 1024);
+ * configMap.put("topP", 0.9);
+ * 
+ * Map<String, Object> thinkingConfigMap = new HashMap<>();
+ * thinkingConfigMap.put("includeThoughts", true);
+ * thinkingConfigMap.put("thinkingBudget", 1024);
+ * configMap.put("thinkingConfig", thinkingConfigMap);
+ * 
+ * GenerationConfig config = GeminiConfigConverter.toGenerationConfig(configMap);
+ * }</pre>
+ *
+ * @author cwdhf
+ * @since 3.1
+ */
+public class GeminiConfigConverter {
+
+    /**
+     * 将 Map 转换为 GenerationConfig 对象
+     *
+     * @param configMap 配置Map，key为字段名，value为字段值
+     * @return GenerationConfig 对象
+     */
+    public static GenerationConfig toGenerationConfig(Map<String, Object> configMap) {
+        if (configMap == null || configMap.isEmpty()) {
+            return new GenerationConfig();
+        }
+        
+        GenerationConfig config = new GenerationConfig();
+        setConfigValues(config, configMap);
+        return config;
+    }
+
+    /**
+     * 将 Map 转换为 ThinkingConfig 对象
+     *
+     * @param configMap 配置Map
+     * @return ThinkingConfig 对象
+     */
+    public static ThinkingConfig toThinkingConfig(Map<String, Object> configMap) {
+        if (configMap == null || configMap.isEmpty()) {
+            return new ThinkingConfig();
+        }
+        
+        ThinkingConfig config = new ThinkingConfig();
+        setConfigValues(config, configMap);
+        return config;
+    }
+
+    /**
+     * 将 Map 转换为 SpeechConfig 对象
+     *
+     * @param configMap 配置Map
+     * @return SpeechConfig 对象
+     */
+    public static SpeechConfig toSpeechConfig(Map<String, Object> configMap) {
+        if (configMap == null || configMap.isEmpty()) {
+            return new SpeechConfig();
+        }
+        
+        SpeechConfig config = new SpeechConfig();
+        setConfigValues(config, configMap);
+        return config;
+    }
+
+    /**
+     * 将 Map 转换为 ImageConfig 对象
+     *
+     * @param configMap 配置Map
+     * @return ImageConfig 对象
+     */
+    public static ImageConfig toImageConfig(Map<String, Object> configMap) {
+        if (configMap == null || configMap.isEmpty()) {
+            return new ImageConfig();
+        }
+        
+        ImageConfig config = new ImageConfig();
+        setConfigValues(config, configMap);
+        return config;
+    }
+
+    /**
+     * 将 Map 转换为 Schema 对象
+     *
+     * @param configMap 配置Map
+     * @return Schema 对象
+     */
+    public static Schema toSchema(Map<String, Object> configMap) {
+        if (configMap == null || configMap.isEmpty()) {
+            return new Schema();
+        }
+        
+        Schema schema = new Schema();
+        setConfigValues(schema, configMap);
+        return schema;
+    }
+
+    /**
+     * 设置配置对象的值
+     *
+     * @param configObject 配置对象
+     * @param configMap 配置Map
+     */
+    @SuppressWarnings("unchecked")
+    private static void setConfigValues(Object configObject, Map<String, Object> configMap) {
+        Class<?> clazz = configObject.getClass();
+        
+        for (Map.Entry<String, Object> entry : configMap.entrySet()) {
+            String fieldName = entry.getKey();
+            Object fieldValue = entry.getValue();
+            
+            if (fieldValue == null) {
+                continue;
+            }
+            
+            try {
+                Field field = findField(clazz, fieldName);
+                if (field == null) {
+                    continue;
+                }
+                
+                field.setAccessible(true);
+                Class<?> fieldType = field.getType();
+                Object convertedValue = convertValue(fieldValue, fieldType, field);
+                field.set(configObject, convertedValue);
+                
+            } catch (IllegalAccessException e) {
+                // 忽略无法访问的字段
+            }
+        }
+    }
+
+    /**
+     * 查找字段（支持驼峰命名和下划线命名的匹配）
+     */
+    private static Field findField(Class<?> clazz, String fieldName) {
+        // 直接查找
+        try {
+            return clazz.getDeclaredField(fieldName);
+        } catch (NoSuchFieldException e) {
+            // 尝试驼峰转下划线
+            String snakeCaseName = toSnakeCase(fieldName);
+            try {
+                return clazz.getDeclaredField(snakeCaseName);
+            } catch (NoSuchFieldException e2) {
+                return null;
+            }
+        }
+    }
+
+    /**
+     * 驼峰命名转下划线命名
+     */
+    private static String toSnakeCase(String camelCase) {
+        if (camelCase == null || camelCase.isEmpty()) {
+            return camelCase;
+        }
+        
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < camelCase.length(); i++) {
+            char c = camelCase.charAt(i);
+            if (Character.isUpperCase(c)) {
+                if (i > 0) {
+                    result.append('_');
+                }
+                result.append(Character.toLowerCase(c));
+            } else {
+                result.append(c);
+            }
+        }
+        return result.toString();
+    }
+
+    /**
+     * 转换值为目标类型
+     */
+    @SuppressWarnings("unchecked")
+    private static Object convertValue(Object value, Class<?> targetType, Field field) {
+        // 基本类型转换
+        if (targetType == String.class) {
+            return value.toString();
+        }
+        
+        if (targetType == Integer.class || targetType == int.class) {
+            return toInteger(value);
+        }
+        
+        if (targetType == Long.class || targetType == long.class) {
+            return toLong(value);
+        }
+        
+        if (targetType == Double.class || targetType == double.class) {
+            return toDouble(value);
+        }
+        
+        if (targetType == Boolean.class || targetType == boolean.class) {
+            return toBoolean(value);
+        }
+        
+        // 枚举类型转换
+        if (targetType.isEnum()) {
+            return convertToEnum(value, targetType);
+        }
+        
+        // 列表类型转换
+        if (List.class.isAssignableFrom(targetType)) {
+            return toList(value, targetType, field);
+        }
+        
+        // Map类型转换（用于嵌套对象）
+        if (Map.class.isAssignableFrom(targetType)) {
+            return toMap(value, targetType, field);
+        }
+        
+        // 嵌套配置对象转换
+        if (value instanceof Map) {
+            return convertToNestedConfig(value, targetType);
+        }
+        
+        return value;
+    }
+
+    /**
+     * 转换为整数
+     */
+    private static Integer toInteger(Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).intValue();
+        }
+        try {
+            return Integer.parseInt(value.toString());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * 转换为长整数
+     */
+    private static Long toLong(Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        try {
+            return Long.parseLong(value.toString());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * 转换为双精度浮点数
+     */
+    private static Double toDouble(Object value) {
+        if (value instanceof Number) {
+            return ((Number) value).doubleValue();
+        }
+        try {
+            return Double.parseDouble(value.toString());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * 转换为布尔值
+     */
+    private static Boolean toBoolean(Object value) {
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        String str = value.toString().toLowerCase();
+        return "true".equals(str) || "1".equals(str);
+    }
+
+    /**
+     * 转换为枚举
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static Enum<?> convertToEnum(Object value, Class<?> enumType) {
+        String enumName = value.toString().toUpperCase();
+        
+        try {
+            return Enum.valueOf((Class<Enum>) enumType, enumName);
+        } catch (IllegalArgumentException e) {
+            if (enumName.contains("_")) {
+                String simpleName = enumName.substring(enumName.lastIndexOf("_") + 1);
+                try {
+                    return Enum.valueOf((Class<Enum>) enumType, simpleName);
+                } catch (IllegalArgumentException e2) {
+                    return findEnumBySimpleName(enumType, enumName);
+                }
+            } else {
+                return findEnumBySimpleName(enumType, enumName);
+            }
+        }
+    }
+    
+    /**
+     * 根据简单名称查找枚举值（忽略前缀）
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static Enum<?> findEnumBySimpleName(Class<?> enumType, String simpleName) {
+        Object[] constants = enumType.getEnumConstants();
+        if (constants == null) {
+            return null;
+        }
+        
+        for (Object constant : constants) {
+            String enumConstantName = ((Enum<?>) constant).name();
+            if (enumConstantName.endsWith("_" + simpleName) || enumConstantName.equals(simpleName)) {
+                return (Enum<?>) constant;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 转换为列表
+     */
+    @SuppressWarnings("unchecked")
+    private static List<Object> toList(Object value, Class<?> targetType, Field field) {
+        if (value instanceof List) {
+            List<Object> originalList = (List<Object>) value;
+            
+            // 获取列表的元素类型
+            Class<?> elementType = getFieldElementType(field);
+            if (elementType == null || elementType == Object.class) {
+                return originalList;
+            }
+            
+            // 转换每个元素
+            List<Object> result = new ArrayList<>(originalList.size());
+            for (Object item : originalList) {
+                if (item instanceof Map) {
+                    result.add(convertToNestedConfig(item, elementType));
+                } else if (elementType.isEnum() && item instanceof String) {
+                    result.add(convertToEnum(item, elementType));
+                } else {
+                    result.add(item);
+                }
+            }
+            return result;
+        }
+        
+        if (value instanceof Collection) {
+            return new ArrayList<>((Collection<?>) value);
+        }
+        
+        return Collections.singletonList(value);
+    }
+    
+    /**
+     * 获取字段的泛型元素类型
+     */
+    private static Class<?> getFieldElementType(Field field) {
+        java.lang.reflect.Type genericType = field.getGenericType();
+        if (genericType instanceof java.lang.reflect.ParameterizedType) {
+            java.lang.reflect.ParameterizedType paramType = (java.lang.reflect.ParameterizedType) genericType;
+            java.lang.reflect.Type[] actualTypeArguments = paramType.getActualTypeArguments();
+            if (actualTypeArguments.length > 0 && actualTypeArguments[0] instanceof Class) {
+                return (Class<?>) actualTypeArguments[0];
+            }
+        }
+        return null;
+    }
+    
+    /**
+     * 转换为Map
+     */
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> toMap(Object value, Class<?> targetType, Field field) {
+        if (value instanceof Map) {
+            Map<String, Object> originalMap = (Map<String, Object>) value;
+            
+            // 获取Map的值类型
+            Class<?> valueType = getFieldValueType(field);
+            if (valueType == null || valueType == Object.class) {
+                return originalMap;
+            }
+            
+            // 转换每个值
+            Map<String, Object> result = new java.util.LinkedHashMap<>(originalMap.size());
+            for (Map.Entry<String, Object> entry : originalMap.entrySet()) {
+                Object item = entry.getValue();
+                if (item instanceof Map) {
+                    result.put(entry.getKey(), convertToNestedConfig(item, valueType));
+                } else if (valueType.isEnum() && item instanceof String) {
+                    result.put(entry.getKey(), convertToEnum(item, valueType));
+                } else {
+                    result.put(entry.getKey(), item);
+                }
+            }
+            return result;
+        }
+        return null;
+    }
+    
+    /**
+     * 获取字段的泛型值类型
+     */
+    private static Class<?> getFieldValueType(Field field) {
+        java.lang.reflect.Type genericType = field.getGenericType();
+        if (genericType instanceof java.lang.reflect.ParameterizedType) {
+            java.lang.reflect.ParameterizedType paramType = (java.lang.reflect.ParameterizedType) genericType;
+            java.lang.reflect.Type[] actualTypeArguments = paramType.getActualTypeArguments();
+            if (actualTypeArguments.length > 1 && actualTypeArguments[1] instanceof Class) {
+                return (Class<?>) actualTypeArguments[1];
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 转换为嵌套配置对象
+     */
+    @SuppressWarnings("unchecked")
+    private static Object convertToNestedConfig(Object value, Class<?> targetType) {
+        Map<String, Object> nestedMap = (Map<String, Object>) value;
+        
+        // 根据目标类型创建对象
+        if (targetType == GenerationConfig.class) {
+            return toGenerationConfig(nestedMap);
+        } else if (targetType == ThinkingConfig.class) {
+            return toThinkingConfig(nestedMap);
+        } else if (targetType == SpeechConfig.class) {
+            return toSpeechConfig(nestedMap);
+        } else if (targetType == ImageConfig.class) {
+            return toImageConfig(nestedMap);
+        } else if (targetType == Schema.class) {
+            return toSchema(nestedMap);
+        } else if (targetType == SpeechConfig.VoiceConfig.class) {
+            return toVoiceConfig(nestedMap);
+        } else if (targetType == SpeechConfig.PrebuiltVoiceConfig.class) {
+            return toPrebuiltVoiceConfig(nestedMap);
+        } else if (targetType == SpeechConfig.MultiSpeakerVoiceConfig.class) {
+            return toMultiSpeakerVoiceConfig(nestedMap);
+        } else if (targetType == SpeechConfig.SpeakerVoiceConfig.class) {
+            return toSpeakerVoiceConfig(nestedMap);
+        }
+        
+        // 通用反射转换
+        try {
+            Object nestedObject = targetType.newInstance();
+            setConfigValues(nestedObject, nestedMap);
+            return nestedObject;
+        } catch (InstantiationException | IllegalAccessException e) {
+            return null;
+        }
+    }
+
+    /**
+     * 将 Map 转换为 VoiceConfig 对象
+     */
+    public static SpeechConfig.VoiceConfig toVoiceConfig(Map<String, Object> configMap) {
+        if (configMap == null || configMap.isEmpty()) {
+            return new SpeechConfig.VoiceConfig();
+        }
+        
+        SpeechConfig.VoiceConfig config = new SpeechConfig.VoiceConfig();
+        setConfigValues(config, configMap);
+        return config;
+    }
+
+    /**
+     * 将 Map 转换为 PrebuiltVoiceConfig 对象
+     */
+    public static SpeechConfig.PrebuiltVoiceConfig toPrebuiltVoiceConfig(Map<String, Object> configMap) {
+        if (configMap == null || configMap.isEmpty()) {
+            return new SpeechConfig.PrebuiltVoiceConfig();
+        }
+        
+        SpeechConfig.PrebuiltVoiceConfig config = new SpeechConfig.PrebuiltVoiceConfig();
+        setConfigValues(config, configMap);
+        return config;
+    }
+
+    /**
+     * 将 Map 转换为 MultiSpeakerVoiceConfig 对象
+     */
+    public static SpeechConfig.MultiSpeakerVoiceConfig toMultiSpeakerVoiceConfig(Map<String, Object> configMap) {
+        if (configMap == null || configMap.isEmpty()) {
+            return new SpeechConfig.MultiSpeakerVoiceConfig();
+        }
+        
+        SpeechConfig.MultiSpeakerVoiceConfig config = new SpeechConfig.MultiSpeakerVoiceConfig();
+        setConfigValues(config, configMap);
+        return config;
+    }
+
+    /**
+     * 将 Map 转换为 SpeakerVoiceConfig 对象
+     */
+    public static SpeechConfig.SpeakerVoiceConfig toSpeakerVoiceConfig(Map<String, Object> configMap) {
+        if (configMap == null || configMap.isEmpty()) {
+            return new SpeechConfig.SpeakerVoiceConfig();
+        }
+        
+        SpeechConfig.SpeakerVoiceConfig config = new SpeechConfig.SpeakerVoiceConfig();
+        setConfigValues(config, configMap);
+        return config;
+    }
+
+    /**
+     * 安全地获取嵌套Map中的值
+     *
+     * @param map 源Map
+     * @param keys 嵌套键路径
+     * @return 获取到的值，如果路径不存在则返回null
+     */
+    @SuppressWarnings("unchecked")
+    public static Object getNestedValue(Map<String, Object> map, String... keys) {
+        if (map == null || keys == null || keys.length == 0) {
+            return null;
+        }
+        
+        Object current = map;
+        for (String key : keys) {
+            if (current instanceof Map) {
+                current = ((Map<?, ?>) current).get(key);
+                if (current == null) {
+                    return null;
+                }
+            } else {
+                return null;
+            }
+        }
+        return current;
+    }
+}

--- a/solon-ai-llm-dialects/solon-ai-dialect-gemini/src/main/java/org/noear/solon/ai/llm/dialect/gemini/model/GenerationConfig.java
+++ b/solon-ai-llm-dialects/solon-ai-dialect-gemini/src/main/java/org/noear/solon/ai/llm/dialect/gemini/model/GenerationConfig.java
@@ -1,0 +1,378 @@
+/*
+ * Copyright 2017-2025 noear.org and authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.noear.solon.ai.llm.dialect.gemini.model;
+
+import java.util.List;
+
+/**
+ * Gemini 生成配置
+ * <p>
+ * 用于配置 Gemini API 的生成参数，包括输出格式、采样策略、停止条件等。
+ * 这些配置会影响模型生成内容的方式和格式。
+ * <p>
+ * 示例配置：
+ * <pre>{@code
+ * GenerationConfig config = new GenerationConfig()
+ *     .setTemperature(0.7)
+ *     .setMaxOutputTokens(1024)
+ *     .setTopP(0.9)
+ *     .setResponseMimeType("application/json");
+ * }</pre>
+ *
+ * @author cwdhf
+ * @since 3.1
+ */
+public class GenerationConfig {
+
+    /**
+     * 停止序列列表
+     * <p>
+     * 当模型生成到这些序列之一时，将停止生成并返回结果。
+     * 常用于控制输出格式，如停止于特定的结束标记。
+     */
+    private List<String> stopSequences;
+
+    /**
+     * 响应 MIME 类型
+     * <p>
+     * 指定生成响应的格式类型。支持的类型包括：
+     * <ul>
+     *   <li>"text/plain" - 纯文本（默认）</li>
+     *   <li>"application/json" - JSON 格式</li>
+     * </ul>
+     */
+    private String responseMimeType;
+
+    /**
+     * 响应 Schema
+     * <p>
+     * 当 responseMimeType 为 "application/json" 时，
+     * 此字段指定响应的 JSON Schema，用于约束输出格式。
+     */
+    private Schema responseSchema;
+
+    /**
+     * 响应 JSON Schema（保留字段）
+     * <p>
+     * 内部使用，用于兼容不同版本的 API。
+     */
+    private Object responseJsonSchema;
+
+    /**
+     * 响应模态列表
+     * <p>
+     * 指定生成响应的模态类型，如文本、音频等。
+     */
+    private List<Modality> responseModalities;
+
+    /**
+     * 候选答案数量
+     * <p>
+     * 指定返回的候选答案数量。
+     * 值为 1 到 8 之间的整数。
+     */
+    private Integer candidateCount;
+
+    /**
+     * 最大输出 Token 数量
+     * <p>
+     * 限制生成内容的最大长度，以 Token 为单位。
+     * 不同的模型有不同的最大限制。
+     */
+    private Integer maxOutputTokens;
+
+    /**
+     * 温度
+     * <p>
+     * 控制生成内容的随机性。取值范围 0.0 到 2.0：
+     * <ul>
+     *   <li>较低的值（如 0.2）使输出更加确定性、聚焦</li>
+     *   <li>较高的值（如 0.8）使输出更加随机、多样化</li>
+     * </ul>
+     */
+    private Double temperature;
+
+    /**
+     * Top-P 采样概率
+     * <p>
+     * 控制ucleus 采样的概率质量阈值。
+     * 取值范围 0.0 到 1.0，默认为 0.95。
+     * 较低的值使分布更集中在高概率词上。
+     */
+    private Double topP;
+
+    /**
+     * Top-K 采样
+     * <p>
+     * 控制每次生成时考虑的候选词数量。
+     * 取值范围 1 到 40。
+     * 较低的值使输出更加确定性。
+     */
+    private Integer topK;
+
+    /**
+     * 随机种子
+     * <p>
+     * 用于控制生成结果的确定性。
+     * 相同的种子和配置应该产生相同的结果。
+     */
+    private Long seed;
+
+    /**
+     * 存在惩罚
+     * <p>
+     * 对已出现在生成文本中的 token 进行惩罚，
+     * 取值范围 -2.0 到 2.0，正值减少重复。
+     */
+    private Double presencePenalty;
+
+    /**
+     * 频率惩罚
+     * <p>
+     * 根据 token 在生成文本中的出现频率进行惩罚，
+     * 取值范围 -2.0 到 2.0，正值减少重复。
+     */
+    private Double frequencyPenalty;
+
+    /**
+     * 是否返回 Log probabilities
+     * <p>
+     * 设置为 true 时，返回生成结果的概率信息。
+     */
+    private Boolean responseLogprobs;
+
+    /**
+     * Log probabilities 数量
+     * <p>
+     * 指定每个位置返回多少个最可能的 token 的 log probability。
+     */
+    private Integer logprobs;
+
+    /**
+     * 是否启用增强的公民回答
+     * <p>
+     * 启用后，模型将提供更符合公民责任的回答。
+     */
+    private Boolean enableEnhancedCivicAnswers;
+
+    /**
+     * 语音配置
+     * <p>
+     * 配置语音输出相关的参数。
+     */
+    private SpeechConfig speechConfig;
+
+    /**
+     * 思考配置
+     * <p>
+     * 配置模型思考过程的参数，如是否显示思考过程、思考预算等。
+     */
+    private ThinkingConfig thinkingConfig;
+
+    /**
+     * 图像配置
+     * <p>
+     * 配置图像生成或处理相关的参数。
+     */
+    private ImageConfig imageConfig;
+
+    /**
+     * 媒体分辨率
+     * <p>
+     * 指定生成媒体的分辨率级别。
+     */
+    private MediaResolution mediaResolution;
+
+    public List<String> getStopSequences() {
+        return stopSequences;
+    }
+
+    public GenerationConfig setStopSequences(List<String> stopSequences) {
+        this.stopSequences = stopSequences;
+        return this;
+    }
+
+    public String getResponseMimeType() {
+        return responseMimeType;
+    }
+
+    public GenerationConfig setResponseMimeType(String responseMimeType) {
+        this.responseMimeType = responseMimeType;
+        return this;
+    }
+
+    public Schema getResponseSchema() {
+        return responseSchema;
+    }
+
+    public GenerationConfig setResponseSchema(Schema responseSchema) {
+        this.responseSchema = responseSchema;
+        return this;
+    }
+
+    public Object getResponseJsonSchema() {
+        return responseJsonSchema;
+    }
+
+    public GenerationConfig setResponseJsonSchema(Object responseJsonSchema) {
+        this.responseJsonSchema = responseJsonSchema;
+        return this;
+    }
+
+    public List<Modality> getResponseModalities() {
+        return responseModalities;
+    }
+
+    public GenerationConfig setResponseModalities(List<Modality> responseModalities) {
+        this.responseModalities = responseModalities;
+        return this;
+    }
+
+    public Integer getCandidateCount() {
+        return candidateCount;
+    }
+
+    public GenerationConfig setCandidateCount(Integer candidateCount) {
+        this.candidateCount = candidateCount;
+        return this;
+    }
+
+    public Integer getMaxOutputTokens() {
+        return maxOutputTokens;
+    }
+
+    public GenerationConfig setMaxOutputTokens(Integer maxOutputTokens) {
+        this.maxOutputTokens = maxOutputTokens;
+        return this;
+    }
+
+    public Double getTemperature() {
+        return temperature;
+    }
+
+    public GenerationConfig setTemperature(Double temperature) {
+        this.temperature = temperature;
+        return this;
+    }
+
+    public Double getTopP() {
+        return topP;
+    }
+
+    public GenerationConfig setTopP(Double topP) {
+        this.topP = topP;
+        return this;
+    }
+
+    public Integer getTopK() {
+        return topK;
+    }
+
+    public GenerationConfig setTopK(Integer topK) {
+        this.topK = topK;
+        return this;
+    }
+
+    public Long getSeed() {
+        return seed;
+    }
+
+    public GenerationConfig setSeed(Long seed) {
+        this.seed = seed;
+        return this;
+    }
+
+    public Double getPresencePenalty() {
+        return presencePenalty;
+    }
+
+    public GenerationConfig setPresencePenalty(Double presencePenalty) {
+        this.presencePenalty = presencePenalty;
+        return this;
+    }
+
+    public Double getFrequencyPenalty() {
+        return frequencyPenalty;
+    }
+
+    public GenerationConfig setFrequencyPenalty(Double frequencyPenalty) {
+        this.frequencyPenalty = frequencyPenalty;
+        return this;
+    }
+
+    public Boolean getResponseLogprobs() {
+        return responseLogprobs;
+    }
+
+    public GenerationConfig setResponseLogprobs(Boolean responseLogprobs) {
+        this.responseLogprobs = responseLogprobs;
+        return this;
+    }
+
+    public Integer getLogprobs() {
+        return logprobs;
+    }
+
+    public GenerationConfig setLogprobs(Integer logprobs) {
+        this.logprobs = logprobs;
+        return this;
+    }
+
+    public Boolean getEnableEnhancedCivicAnswers() {
+        return enableEnhancedCivicAnswers;
+    }
+
+    public GenerationConfig setEnableEnhancedCivicAnswers(Boolean enableEnhancedCivicAnswers) {
+        this.enableEnhancedCivicAnswers = enableEnhancedCivicAnswers;
+        return this;
+    }
+
+    public SpeechConfig getSpeechConfig() {
+        return speechConfig;
+    }
+
+    public GenerationConfig setSpeechConfig(SpeechConfig speechConfig) {
+        this.speechConfig = speechConfig;
+        return this;
+    }
+
+    public ThinkingConfig getThinkingConfig() {
+        return thinkingConfig;
+    }
+
+    public GenerationConfig setThinkingConfig(ThinkingConfig thinkingConfig) {
+        this.thinkingConfig = thinkingConfig;
+        return this;
+    }
+
+    public ImageConfig getImageConfig() {
+        return imageConfig;
+    }
+
+    public GenerationConfig setImageConfig(ImageConfig imageConfig) {
+        this.imageConfig = imageConfig;
+        return this;
+    }
+
+    public MediaResolution getMediaResolution() {
+        return mediaResolution;
+    }
+
+    public GenerationConfig setMediaResolution(MediaResolution mediaResolution) {
+        this.mediaResolution = mediaResolution;
+        return this;
+    }
+}

--- a/solon-ai-llm-dialects/solon-ai-dialect-gemini/src/main/java/org/noear/solon/ai/llm/dialect/gemini/model/ImageConfig.java
+++ b/solon-ai-llm-dialects/solon-ai-dialect-gemini/src/main/java/org/noear/solon/ai/llm/dialect/gemini/model/ImageConfig.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2025 noear.org and authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.noear.solon.ai.llm.dialect.gemini.model;
+
+/**
+ * 图像配置
+ * <p>
+ * 用于配置 Gemini API 生成图像时的参数。
+ * 包含图像宽高比、尺寸等配置项。
+ * <p>
+ * 示例配置：
+ * <pre>{@code
+ * ImageConfig config = new ImageConfig()
+ *     .setAspectRatio("16:9")
+ *     .setImageSize("2K");
+ * }</pre>
+ *
+ * @author cwdhf
+ * @since 3.1
+ */
+public class ImageConfig {
+
+    /**
+     * 输出宽高比
+     * <p>
+     * 指定生成图像的宽高比。
+     * 支持的宽高比：1:1, 2:3, 3:2, 3:4, 4:3, 9:16, 16:9, 21:9。
+     * <p>
+     * 如果未指定，模型将根据提供的任何参考图像选择默认宽高比。
+     */
+    private String aspectRatio;
+
+    /**
+     * 图像尺寸
+     * <p>
+     * 指定生成图像的尺寸。
+     * 支持的值：1K, 2K, 4K。
+     * 如果未指定，模型将使用默认值 1K。
+     */
+    private String imageSize;
+
+    public String getAspectRatio() {
+        return aspectRatio;
+    }
+
+    public ImageConfig setAspectRatio(String aspectRatio) {
+        this.aspectRatio = aspectRatio;
+        return this;
+    }
+
+    public String getImageSize() {
+        return imageSize;
+    }
+
+    public ImageConfig setImageSize(String imageSize) {
+        this.imageSize = imageSize;
+        return this;
+    }
+}

--- a/solon-ai-llm-dialects/solon-ai-dialect-gemini/src/main/java/org/noear/solon/ai/llm/dialect/gemini/model/MediaResolution.java
+++ b/solon-ai-llm-dialects/solon-ai-dialect-gemini/src/main/java/org/noear/solon/ai/llm/dialect/gemini/model/MediaResolution.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2025 noear.org and authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.noear.solon.ai.llm.dialect.gemini.model;
+
+/**
+ * 媒体分辨率枚举
+ * <p>
+ * 指定输入媒体的分辨率。
+ * 不同的分辨率会影响处理质量和 token 使用量。
+ * <p>
+ * 示例配置：
+ * <pre>{@code
+ * GenerationConfig config = new GenerationConfig()
+ *     .setMediaResolution(MediaResolution.MEDIA_RESOLUTION_HIGH);
+ * }</pre>
+ *
+ * @author cwdhf
+ * @since 3.1
+ */
+public enum MediaResolution {
+
+    /**
+     * 未指定媒体分辨率
+     * <p>
+     * 媒体分辨率未设置。
+     */
+    MEDIA_RESOLUTION_UNSPECIFIED,
+
+    /**
+     * 低分辨率
+     * <p>
+     * 媒体分辨率设置为低（64 tokens）。
+     * 适用于快速处理或带宽有限的场景。
+     */
+    MEDIA_RESOLUTION_LOW,
+
+    /**
+     * 中等分辨率
+     * <p>
+     * 媒体分辨率设置为中等（256 tokens）。
+     * 平衡了质量和处理速度。
+     */
+    MEDIA_RESOLUTION_MEDIUM,
+
+    /**
+     * 高分辨率
+     * <p>
+     * 媒体分辨率设置为高（带缩放重帧的 256 tokens）。
+     * 适用于需要高质量输出的场景。
+     */
+    MEDIA_RESOLUTION_HIGH
+}

--- a/solon-ai-llm-dialects/solon-ai-dialect-gemini/src/main/java/org/noear/solon/ai/llm/dialect/gemini/model/Modality.java
+++ b/solon-ai-llm-dialects/solon-ai-dialect-gemini/src/main/java/org/noear/solon/ai/llm/dialect/gemini/model/Modality.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2025 noear.org and authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.noear.solon.ai.llm.dialect.gemini.model;
+
+/**
+ * 响应模态枚举
+ * <p>
+ * 指定 Gemini API 响应的内容类型。
+ * 可以组合使用以支持多模态输出。
+ * <p>
+ * 示例配置：
+ * <pre>{@code
+ * List<Modality> modalities = Arrays.asList(
+ *     Modality.TEXT,
+ *     Modality.IMAGE
+ * );
+ * }</pre>
+ *
+ * @author cwdhf
+ * @since 3.1
+ */
+public enum Modality {
+
+    /**
+     * 未指定模态
+     * <p>
+     * 默认值。
+     */
+    MODALITY_UNSPECIFIED,
+
+    /**
+     * 文本模态
+     * <p>
+     * 生成文本形式的响应。
+     */
+    TEXT,
+
+    /**
+     * 图像模态
+     * <p>
+     * 生成图像形式的响应。
+     */
+    IMAGE,
+
+    /**
+     * 音频模态
+     * <p>
+     * 生成音频形式的响应。
+     */
+    AUDIO
+}

--- a/solon-ai-llm-dialects/solon-ai-dialect-gemini/src/main/java/org/noear/solon/ai/llm/dialect/gemini/model/Schema.java
+++ b/solon-ai-llm-dialects/solon-ai-dialect-gemini/src/main/java/org/noear/solon/ai/llm/dialect/gemini/model/Schema.java
@@ -1,0 +1,396 @@
+/*
+ * Copyright 2017-2025 noear.org and authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.noear.solon.ai.llm.dialect.gemini.model;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * JSON Schema 配置
+ * <p>
+ * 用于定义 API 响应的 JSON Schema 结构。
+ * 支持描述对象的属性、数组的元素类型、枚举值等。
+ * <p>
+ * 示例：定义一个用户对象的 Schema
+ * <pre>{@code
+ * Schema userSchema = new Schema()
+ *     .setType(Schema.Type.OBJECT)
+ *     .setDescription("用户信息")
+ *     .addProperty("name", new Schema().setType(Schema.Type.STRING))
+ *     .addProperty("age", new Schema().setType(Schema.Type.INTEGER));
+ * }</pre>
+ *
+ * @author cwdhf
+ * @since 3.1
+ */
+public class Schema {
+
+    /**
+     * Schema 类型枚举
+     */
+    public enum Type {
+        /**
+         * 未指定类型
+         * <p>
+         * 默认值，不应使用。
+         */
+        TYPE_UNSPECIFIED,
+        OBJECT,
+        STRING,
+        NUMBER,
+        INTEGER,
+        BOOLEAN,
+        ARRAY,
+        NULL
+    }
+
+    /**
+     * Schema 类型
+     * <p>
+     * 指定该 Schema 描述的数据类型。
+     */
+    private Type type;
+
+    /**
+     * 描述信息
+     * <p>
+     * 提供该 Schema 的文字说明，用于文档和验证错误提示。
+     * 可以包含使用示例。参数描述可以格式化为 Markdown。
+     */
+    private String description;
+
+    /**
+     * 标题
+     * <p>
+     * Schema 的标题。
+     */
+    private String title;
+
+    /**
+     * 格式
+     * <p>
+     * 指定字符串的格式，如 "date-time"、"email"、"uri" 等。
+     * 任何值都是允许的，但大多数不会触发任何特殊功能。
+     */
+    private String format;
+
+    /**
+     * 属性列表
+     * <p>
+     * 当 type 为 OBJECT 时，定义对象的各个属性及其 Schema。
+     * 包含 "key": value 对的列表。例如：{ "name": "wrench", "mass": "1.3kg", "count": "3" }。
+     */
+    private Map<String, Schema> properties;
+
+    /**
+     * 必填属性列表
+     * <p>
+     * 当 type 为 OBJECT 时，指定必填的属性名称列表。
+     */
+    private List<String> required;
+
+    /**
+     * 最小属性数量
+     * <p>
+     * 当 type 为 OBJECT 时，指定对象的最少属性数量。
+     */
+    private Long minProperties;
+
+    /**
+     * 最大属性数量
+     * <p>
+     * 当 type 为 OBJECT 时，指定对象的最多属性数量。
+     */
+    private Long maxProperties;
+
+    /**
+     * 元素 Schema
+     * <p>
+     * 当 type 为 ARRAY 时，定义数组元素的 Schema。
+     */
+    private Schema items;
+
+    /**
+     * 数组长度最小值
+     * <p>
+     * 当 type 为 ARRAY 时，指定数组的最少元素数量。
+     */
+    private Long minItems;
+
+    /**
+     * 数组长度最大值
+     * <p>
+     * 当 type 为 ARRAY 时，指定数组的最多元素数量。
+     */
+    private Long maxItems;
+
+    /**
+     * 字符串最小长度
+     * <p>
+     * 当 type 为 STRING 时，指定字符串的最小字符数。
+     */
+    private Long minLength;
+
+    /**
+     * 字符串最大长度
+     * <p>
+     * 当 type 为 STRING 时，指定字符串的最大字符数。
+     */
+    private Long maxLength;
+
+    /**
+     * 正则表达式模式
+     * <p>
+     * 当 type 为 STRING 时，使用正则表达式限制字符串格式。
+     */
+    private String pattern;
+
+    /**
+     * 数值最小值
+     * <p>
+     * 当 type 为 NUMBER 或 INTEGER 时，指定最小值。
+     */
+    private Number minimum;
+
+    /**
+     * 数值最大值
+     * <p>
+     * 当 type 为 NUMBER 或 INTEGER 时，指定最大值。
+     */
+    private Number maximum;
+
+    /**
+     * 是否可以为 null
+     */
+    private Boolean nullable;
+
+    /**
+     * 示例值
+     * <p>
+     * 提供该字段的示例值。
+     */
+    private Object example;
+
+    /**
+     * 任意匹配 Schema 列表
+     * <p>
+     * 值应该匹配列表中的任意一个子 Schema。
+     */
+    private List<Schema> anyOf;
+
+    /**
+     * 属性顺序
+     * <p>
+     * 指定属性的顺序。不是 Open API 规范的标准字段。
+     * 用于确定响应中属性的顺序。
+     */
+    private List<String> propertyOrdering;
+
+    public Type getType() {
+        return type;
+    }
+
+    public Schema setType(Type type) {
+        this.type = type;
+        return this;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Schema setDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Schema setTitle(String title) {
+        this.title = title;
+        return this;
+    }
+
+    public String getFormat() {
+        return format;
+    }
+
+    public Schema setFormat(String format) {
+        this.format = format;
+        return this;
+    }
+
+    public Map<String, Schema> getProperties() {
+        return properties;
+    }
+
+    public Schema setProperties(Map<String, Schema> properties) {
+        this.properties = properties;
+        return this;
+    }
+
+    public List<String> getRequiredList() {
+        return required;
+    }
+
+    public Schema setRequiredList(List<String> required) {
+        this.required = required;
+        return this;
+    }
+
+    public Long getMinProperties() {
+        return minProperties;
+    }
+
+    public Schema setMinProperties(Long minProperties) {
+        this.minProperties = minProperties;
+        return this;
+    }
+
+    public Long getMaxProperties() {
+        return maxProperties;
+    }
+
+    public Schema setMaxProperties(Long maxProperties) {
+        this.maxProperties = maxProperties;
+        return this;
+    }
+
+    public Schema getItems() {
+        return items;
+    }
+
+    public Schema setItems(Schema items) {
+        this.items = items;
+        return this;
+    }
+
+    public Long getMinItems() {
+        return minItems;
+    }
+
+    public Schema setMinItems(Long minItems) {
+        this.minItems = minItems;
+        return this;
+    }
+
+    public Long getMaxItems() {
+        return maxItems;
+    }
+
+    public Schema setMaxItems(Long maxItems) {
+        this.maxItems = maxItems;
+        return this;
+    }
+
+    public Long getMinLength() {
+        return minLength;
+    }
+
+    public Schema setMinLength(Long minLength) {
+        this.minLength = minLength;
+        return this;
+    }
+
+    public Long getMaxLength() {
+        return maxLength;
+    }
+
+    public Schema setMaxLength(Long maxLength) {
+        this.maxLength = maxLength;
+        return this;
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    public Schema setPattern(String pattern) {
+        this.pattern = pattern;
+        return this;
+    }
+
+    public Number getMinimum() {
+        return minimum;
+    }
+
+    public Schema setMinimum(Number minimum) {
+        this.minimum = minimum;
+        return this;
+    }
+
+    public Number getMaximum() {
+        return maximum;
+    }
+
+    public Schema setMaximum(Number maximum) {
+        this.maximum = maximum;
+        return this;
+    }
+
+    public Boolean getNullable() {
+        return nullable;
+    }
+
+    public Schema setNullable(Boolean nullable) {
+        this.nullable = nullable;
+        return this;
+    }
+
+    public Object getExample() {
+        return example;
+    }
+
+    public Schema setExample(Object example) {
+        this.example = example;
+        return this;
+    }
+
+    public List<Schema> getAnyOf() {
+        return anyOf;
+    }
+
+    public Schema setAnyOf(List<Schema> anyOf) {
+        this.anyOf = anyOf;
+        return this;
+    }
+
+    public List<String> getPropertyOrdering() {
+        return propertyOrdering;
+    }
+
+    public Schema setPropertyOrdering(List<String> propertyOrdering) {
+        this.propertyOrdering = propertyOrdering;
+        return this;
+    }
+
+    /**
+     * 便捷方法：添加属性
+     *
+     * @param name   属性名称
+     * @param schema 属性 Schema
+     * @return 当前 Schema 实例
+     */
+    public Schema addProperty(String name, Schema schema) {
+        if (this.properties == null) {
+            this.properties = new java.util.LinkedHashMap<>();
+        }
+        this.properties.put(name, schema);
+        return this;
+    }
+}

--- a/solon-ai-llm-dialects/solon-ai-dialect-gemini/src/main/java/org/noear/solon/ai/llm/dialect/gemini/model/SpeechConfig.java
+++ b/solon-ai-llm-dialects/solon-ai-dialect-gemini/src/main/java/org/noear/solon/ai/llm/dialect/gemini/model/SpeechConfig.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2017-2025 noear.org and authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.noear.solon.ai.llm.dialect.gemini.model;
+
+/**
+ * 语音配置
+ * <p>
+ * 用于配置 Gemini API 生成语音输出时的参数。
+ * 包含语音选择、语言代码等配置项。
+ * <p>
+ * 示例配置：
+ * <pre>{@code
+ * SpeechConfig config = new SpeechConfig()
+ *     .setVoiceConfig(new VoiceConfig()
+ *         .setPrebuiltVoiceConfig(new PrebuiltVoiceConfig()
+ *             .setVoiceName("en-US-Wavenet-A")))
+ *     .setLanguageCode("en-US");
+ * }</pre>
+ *
+ * @author cwdhf
+ * @since 3.1
+ */
+public class SpeechConfig {
+
+    /**
+     * 语音配置
+     * <p>
+     * 单语音输出时的配置。
+     * 与 multiSpeakerVoiceConfig 互斥。
+     */
+    private VoiceConfig voiceConfig;
+
+    /**
+     * 多说话者语音配置
+     * <p>
+     * 多说话者设置的配置。
+     * 与 voiceConfig 字段互斥。
+     */
+    private MultiSpeakerVoiceConfig multiSpeakerVoiceConfig;
+
+    /**
+     * 语言代码
+     * <p>
+     * 语音合成的语言代码（BCP 47 格式，如 "en-US"）。
+     * <p>
+     * 有效值包括：de-DE, en-AU, en-GB, en-IN, en-US, es-US, fr-FR, hi-IN, pt-BR,
+     * ar-XA, es-ES, fr-CA, id-ID, it-IT, ja-JP, tr-TR, vi-VN, bn-IN, gu-IN,
+     * kn-IN, ml-IN, mr-IN, ta-IN, te-IN, nl-NL, ko-KR, cmn-CN, pl-PL, ru-RU, 和 th-TH。
+     */
+    private String languageCode;
+
+    public VoiceConfig getVoiceConfig() {
+        return voiceConfig;
+    }
+
+    public SpeechConfig setVoiceConfig(VoiceConfig voiceConfig) {
+        this.voiceConfig = voiceConfig;
+        return this;
+    }
+
+    public MultiSpeakerVoiceConfig getMultiSpeakerVoiceConfig() {
+        return multiSpeakerVoiceConfig;
+    }
+
+    public SpeechConfig setMultiSpeakerVoiceConfig(MultiSpeakerVoiceConfig multiSpeakerVoiceConfig) {
+        this.multiSpeakerVoiceConfig = multiSpeakerVoiceConfig;
+        return this;
+    }
+
+    public String getLanguageCode() {
+        return languageCode;
+    }
+
+    public SpeechConfig setLanguageCode(String languageCode) {
+        this.languageCode = languageCode;
+        return this;
+    }
+
+    /**
+     * 语音配置
+     * <p>
+     * 用于指定要使用的语音配置。
+     */
+    public static class VoiceConfig {
+
+        /**
+         * 预构建语音配置
+         * <p>
+         * 要使用的预构建语音的配置。
+         */
+        private PrebuiltVoiceConfig prebuiltVoiceConfig;
+
+        public PrebuiltVoiceConfig getPrebuiltVoiceConfig() {
+            return prebuiltVoiceConfig;
+        }
+
+        public VoiceConfig setPrebuiltVoiceConfig(PrebuiltVoiceConfig prebuiltVoiceConfig) {
+            this.prebuiltVoiceConfig = prebuiltVoiceConfig;
+            return this;
+        }
+    }
+
+    /**
+     * 预构建语音配置
+     * <p>
+     * 用于指定要使用的预构建说话者。
+     */
+    public static class PrebuiltVoiceConfig {
+
+        /**
+         * 语音名称
+         * <p>
+         * 要使用的预设语音的名称。
+         */
+        private String voiceName;
+
+        public String getVoiceName() {
+            return voiceName;
+        }
+
+        public PrebuiltVoiceConfig setVoiceName(String voiceName) {
+            this.voiceName = voiceName;
+            return this;
+        }
+    }
+
+    /**
+     * 多说话者语音配置
+     * <p>
+     * 用于多说话者设置的配置。
+     */
+    public static class MultiSpeakerVoiceConfig {
+
+        /**
+         * 说话者语音配置列表
+         * <p>
+         * 多说话者设置中每个说话者的配置。
+         */
+        private java.util.List<SpeakerVoiceConfig> speakerVoiceConfigs;
+
+        public java.util.List<SpeakerVoiceConfig> getSpeakerVoiceConfigs() {
+            return speakerVoiceConfigs;
+        }
+
+        public MultiSpeakerVoiceConfig setSpeakerVoiceConfigs(java.util.List<SpeakerVoiceConfig> speakerVoiceConfigs) {
+            this.speakerVoiceConfigs = speakerVoiceConfigs;
+            return this;
+        }
+    }
+
+    /**
+     * 说话者语音配置
+     * <p>
+     * 多说话者设置中单个说话者的配置。
+     */
+    public static class SpeakerVoiceConfig {
+
+        /**
+         * 说话者名称
+         * <p>
+         * 要使用的说话者名称。
+         * 应与提示词中的名称相同。
+         */
+        private String speaker;
+
+        /**
+         * 语音配置
+         * <p>
+         * 要使用的语音配置。
+         */
+        private VoiceConfig voiceConfig;
+
+        public String getSpeaker() {
+            return speaker;
+        }
+
+        public SpeakerVoiceConfig setSpeaker(String speaker) {
+            this.speaker = speaker;
+            return this;
+        }
+
+        public VoiceConfig getVoiceConfig() {
+            return voiceConfig;
+        }
+
+        public SpeakerVoiceConfig setVoiceConfig(VoiceConfig voiceConfig) {
+            this.voiceConfig = voiceConfig;
+            return this;
+        }
+    }
+}

--- a/solon-ai-llm-dialects/solon-ai-dialect-gemini/src/main/java/org/noear/solon/ai/llm/dialect/gemini/model/ThinkingConfig.java
+++ b/solon-ai-llm-dialects/solon-ai-dialect-gemini/src/main/java/org/noear/solon/ai/llm/dialect/gemini/model/ThinkingConfig.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2017-2025 noear.org and authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.noear.solon.ai.llm.dialect.gemini.model;
+
+/**
+ * 思考配置
+ * <p>
+ * 用于配置 Gemini 模型的思考过程（Thinking）相关参数。
+ * 支持启用或禁用思考过程显示，以及设置思考的 Token 预算。
+ * <p>
+ * 思考过程是 Gemini 模型在生成最终回答前的内部推理过程，
+ * 启用后可以在响应中查看模型的思考步骤。
+ * <p>
+ * 示例配置：
+ * <pre>{@code
+ * ThinkingConfig config = new ThinkingConfig()
+ *     .setIncludeThoughts(true)
+ *     .setThinkingBudget(1024);
+ * }</pre>
+ *
+ * @author cwdhf
+ * @since 3.1
+ */
+public class ThinkingConfig {
+
+    /**
+     * 是否包含思考内容
+     * <p>
+     * 设置为 true 时，响应中将包含模型的思考过程。
+     * 设置为 false 时，不显示思考过程，只返回最终回答。
+     * <p>
+     * 思考内容会标记在 "**<text>**" 和 "**<text>**" 之间。
+     */
+    private Boolean includeThoughts;
+
+    /**
+     * 思考预算
+     * <p>
+     * 指定用于思考过程的 Token 数量上限。
+     * 取值范围：1 到 24576 之间的整数。
+     * <ul>
+     *   <li>较小的值（如 1024）：限制思考深度，减少延迟</li>
+     *   <li>较大的值（如 8192）：允许更深入的推理，但会增加延迟</li>
+     * </ul>
+     * <p>
+     * 注意：此值必须小于 maxOutputTokens。
+     */
+    private Integer thinkingBudget;
+
+    /**
+     * 思考级别
+     * <p>
+     * 控制模型在生成响应之前的内部推理过程的最大深度。
+     * 如果未指定，默认为 HIGH。
+     * <p>
+     * 推荐用于 Gemini 3 或更高版本的模型。
+     * 在早期模型上使用会导致错误。
+     */
+    private ThinkingLevel thinkingLevel;
+
+    public Boolean getIncludeThoughts() {
+        return includeThoughts;
+    }
+
+    public ThinkingConfig setIncludeThoughts(Boolean includeThoughts) {
+        this.includeThoughts = includeThoughts;
+        return this;
+    }
+
+    public Integer getThinkingBudget() {
+        return thinkingBudget;
+    }
+
+    public ThinkingConfig setThinkingBudget(Integer thinkingBudget) {
+        this.thinkingBudget = thinkingBudget;
+        return this;
+    }
+
+    public ThinkingLevel getThinkingLevel() {
+        return thinkingLevel;
+    }
+
+    public ThinkingConfig setThinkingLevel(ThinkingLevel thinkingLevel) {
+        this.thinkingLevel = thinkingLevel;
+        return this;
+    }
+
+    /**
+     * 思考级别枚举
+     * <p>
+     * 允许用户使用枚举而不是整数预算来指定思考深度。
+     */
+    public enum ThinkingLevel {
+
+        /**
+         * 未指定思考级别
+         * <p>
+         * 默认值。
+         */
+        THINKING_LEVEL_UNSPECIFIED,
+
+        /**
+         * 低思考级别
+         * <p>
+         * 较浅的推理深度。
+         */
+        LOW,
+
+        /**
+         * 高思考级别
+         * <p>
+         * 较深的推理深度。
+         */
+        HIGH
+    }
+}


### PR DESCRIPTION
添加 Gemini 相关的模型请求时的参数支持，对参数进行了实体封装，包括 Modality、MediaResolution、ImageConfig、ThinkingConfig、SpeechConfig、Schema 和 GenerationConfig 新增 GeminiConfigConverter 工具类用于配置转换
重构 GeminiChatDialect 中的配置处理逻辑，使用新的配置类和转换工具
