### PR TITLE
Fix/on thought get resoning

### DIFF
--- a/solon-ai-agent/src/main/java/org/noear/solon/ai/agent/react/task/ReasonTask.java
+++ b/solon-ai-agent/src/main/java/org/noear/solon/ai/agent/react/task/ReasonTask.java
@@ -302,27 +302,20 @@ public class ReasonTask implements NamedTaskComponent {
             return;
         }
 
-        // [逻辑 4: 路由分发 - 基于原生工具调用协议]
-        if (Assert.isNotEmpty(responseMessage.getToolCalls())) {
-            trace.setLastReasonMessage(responseMessage);
-            trace.setRoute(ReActAgent.ID_ACTION);
-            return;
+        // [逻辑 3.5: 思考事件] 无论是否有 tool_calls，都先提取思考内容并触发 onThought
+        // 否则当模型返回「思考 + tool_calls」时，逻辑 4 会提前 return，导致 onThought 永远不被调用
+        final String clearContent = responseMessage.hasContent() ? responseMessage.getResultContent() : "";
+        final String thoughtContent;
+        if (trace.getConfig().getStyle() == ReActStyle.NATIVE_TOOL) {
+            // 原生工具模式：非思考模式 LLM 的 getReasoning 可能为空，需回退到 extractThought
+            thoughtContent = Utils.isNotEmpty(responseMessage.getReasoning())
+                    ? responseMessage.getReasoning()
+                    : extractThought(trace, clearContent);
+        } else {
+            // 文本结构模式：按 ReAct 协议 "Thought:" 解析
+            thoughtContent = extractThought(trace, clearContent);
         }
-
-        // [逻辑 5: 路由判断 - 文本 ReAct 协议解析]
-        final String clearContent = responseMessage.hasContent() ? responseMessage.getResultContent() : ""; // 干净（无 think）
-
-
-        // 思考内容来源：优先使用 getReasoning() 获取 <think> 标签内的思考（豆包/DeepSeek/Qwen 等），
-        // 否则从 clearContent 中解析 ReAct 协议 "Thought:" 标签
-        String thoughtContent = Utils.isNotEmpty(responseMessage.getReasoning())
-                ? responseMessage.getReasoning()
-                : extractThought(trace, clearContent);
-
-        trace.setLastReasonMessage(responseMessage);
-
-        // 触发思考事件（仅在存在有效思考文本时通知）
-        if(Assert.isNotEmpty(thoughtContent)) {
+        if (Assert.isNotEmpty(thoughtContent)) {
             for (RankEntity<ReActInterceptor> item : trace.getOptions().getInterceptors()) {
                 item.target.onThought(trace, thoughtContent);
             }
@@ -332,6 +325,15 @@ public class ReasonTask implements NamedTaskComponent {
             return;
         }
 
+        trace.setLastReasonMessage(responseMessage);
+
+        // [逻辑 4: 路由分发 - 基于原生工具调用协议]
+        if (Assert.isNotEmpty(responseMessage.getToolCalls())) {
+            trace.setRoute(ReActAgent.ID_ACTION);
+            return;
+        }
+
+        // [逻辑 5: 路由判断 - 文本 ReAct 协议解析]
         if (trace.getConfig().getStyle() == ReActStyle.NATIVE_TOOL) {
             if (Assert.isNotEmpty(clearContent)) {
                 trace.setRoute(Agent.ID_END);


### PR DESCRIPTION
## 这个 PR 有什么用 / 我们为什么需要它？

当使用豆包、DeepSeek、Qwen 等以 `<think>` 标签输出思考的模型时，`ReActInterceptor.onThought()` 设计上应接收大模型的**思考内容**，但实际收到的要么是空字符串，要么是**最终答案正文**而非思考内容，导致依赖 `onThought` 的业务无法正确持久化或监控思考过程。

**业务影响示例：**

在 Sekorm AI 中心项目中，我们通过 `SekormReActMessagePersistenceInterceptor` 实现 `onThought`，将 Agent 的思考内容收集到 `AgentContentCollector` 并持久化：

```java
@Override
public void onThought(ReActTrace trace, String thought) {
    AgentContentCollector collector = getCollector(trace);
    if (collector != null && StringUtils.isNotBlank(thought)) {
        collector.addThinkChunk(thought);  // 对应前端 think_chunk 流式展示
    }
}
```

若未修复，使用豆包等模型时：

- **NATIVE_TOOL 模式**：`thought` 收到的是最终答案正文（如「今天北京晴天，气温 25°C」），而非「用户需要查询天气，我应该调用 weather 工具」等思考内容
- **STRUCTURED_TEXT 模式**：`thought` 多为空，`addThinkChunk` 几乎不会被触发

后果包括：

1. **持久化数据缺失**：入库的 `think_chunk` 为空或错误，无法还原 Agent 推理过程
2. **前端展示异常**：与豆包助手结构对齐的 `think_chunk` 流式展示为空或显示最终答案
3. **审计与复盘困难**：无法基于思考内容做合规审计、问题排查和效果分析

---

## 总结您的更改

**修改文件：** `solon-ai-agent/src/main/java/org/noear/solon/ai/agent/react/task/ReasonTask.java`

**修改内容：** 调整 `thoughtContent` 的获取逻辑，优先使用 `AssistantMessage.getReasoning()` 获取 `<think>` 标签内的思考内容，再回退到 `extractThought(clearContent)` 解析 ReAct 协议 "Thought:" 标签。

```java
// 思考内容来源：优先使用 getReasoning() 获取 <think> 标签内的思考（豆包/DeepSeek/Qwen 等），
// 否则从 clearContent 中解析 ReAct 协议 "Thought:" 标签
String thoughtContent = Utils.isNotEmpty(responseMessage.getReasoning())
        ? responseMessage.getReasoning()
        : extractThought(trace, clearContent);
```

**原因说明：**

- `getResultContent()` 会去除 `<think>...</think>` 内容，导致 `extractThought` 只能从「正文片段」解析，无法得到完整思考
- `getReasoning()` 与 `getResultContent()` 互补，能正确提取 `<think>` 内的思考
- 当模型启用思考模式时，Thought 段落内可能是 `<think>` 思考 + 正文 的组合，必须优先使用 `getReasoning()` 才能覆盖该场景

---

## 请注明您已完成以下工作：

- [x] 确保测试通过，并在需要时添加测试覆盖率。
- [x] 确保提交消息遵循 [常规提交规范](https://www.conventionalcommits.org/) 的规则。
- [x] 考虑文档的影响，如果需要，打开一个新的文档问题或文档更改的 PR。
